### PR TITLE
feat: Adjusted /home UI layout and Implement page navigation

### DIFF
--- a/frontend/admin/src/components/Button/AddButton.jsx
+++ b/frontend/admin/src/components/Button/AddButton.jsx
@@ -1,0 +1,52 @@
+import { Box } from "@mui/material";
+
+export default function AddButton({ onClick }) {
+  return (
+    <>
+      <Box
+        sx={{
+          position: "fixed",
+          bottom: "20px",
+          right: "20px",
+          width: "clamp(3.75rem, 3.214rem + 2.68vw, 5.625rem)",
+          height: "clamp(3.75rem, 3.214rem + 2.68vw, 5.625rem)",
+          backgroundColor: "#f2a24a",
+          borderRadius: "50%",
+          boxShadow: "5px 6px 6px rgba(0, 0, 0, 0.2)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          cursor: "pointer",
+        }}
+        onClick={onClick}
+      >
+        <Box
+          sx={{
+            position: "relative",
+            width: "40%", // プラスマークの大きさ(幅)
+            height: "40%", // プラスマークの大きさ(高さ)
+            "&::before, &::after": {
+              content: '""',
+              position: "absolute",
+              backgroundColor: "#fff",
+            },
+            "&::before": {
+              width: "100%",
+              height: "15%", // 横線の太さ
+              top: "50%",
+              left: "0",
+              transform: "translateY(-50%)",
+            },
+            "&::after": {
+              width: "15%", // 縦線の太さ
+              height: "100%",
+              left: "50%",
+              top: "0",
+              transform: "translateX(-50%)",
+            },
+          }}
+        />
+      </Box>
+    </>
+  );
+}

--- a/frontend/admin/src/components/GlobalComponents/NavBar.jsx
+++ b/frontend/admin/src/components/GlobalComponents/NavBar.jsx
@@ -4,8 +4,14 @@ import logo from "../../../public/logo.svg"; // ロゴのパス
 import styled from "styled-components";
 import Stack from "@mui/material/Stack";
 import AccountCircleSharpIcon from "@mui/icons-material/AccountCircleSharp";
+import { useNavigate } from "react-router-dom";
 
 function NavBar() {
+  // ロゴクリックでホーム画面に遷移
+  const navigate = useNavigate();
+  const handleGoBackHome = () => {
+    navigate("/admin/home");
+  };
   return (
     <>
       <AppBar
@@ -29,7 +35,25 @@ function NavBar() {
             paddingRight: "clamp(0.25rem, 0.036rem + 1.07vw, 1rem)",
           }}
         >
-          <Logo src={logo} alt="MenuCare Logo" />
+          <Logo
+            src={logo}
+            alt="MenuCare Logo"
+            sx={{
+              //   position: "fixed",
+              //   bottom: "20px",
+              //   right: "20px",
+              //   width: "clamp(3.75rem, 3.214rem + 2.68vw, 5.625rem)",
+              //   height: "clamp(3.75rem, 3.214rem + 2.68vw, 5.625rem)",
+              //   backgroundColor: "#f2a24a",
+              //   borderRadius: "50%",
+              //   boxShadow: "5px 6px 6px rgba(0, 0, 0, 0.2)",
+              //   display: "flex",
+              //   alignItems: "center",
+              //   justifyContent: "center",
+              cursor: "pointer",
+            }}
+            onClick={handleGoBackHome}
+          />
           <Typography
             variant="h6"
             component="div"

--- a/frontend/admin/src/components/Menu/MenuItem.jsx
+++ b/frontend/admin/src/components/Menu/MenuItem.jsx
@@ -67,6 +67,7 @@ const MenuItem = ({ item }) => {
               sx={{
                 color: "#756e68",
                 paddingLeft: "5px",
+                fontSize: "15px",
               }}
             >
               アレルギー情報
@@ -104,7 +105,7 @@ const MenuItem = ({ item }) => {
                 sx={{
                   color: "#3c3a37",
                   fontFamily: "'Noto Sans JP', sans-serif",
-                  fontSize: "18px",
+                  fontSize: "clamp(15px, 3vw, 18px)",
                 }}
               >
                 {item.allergies && item.allergies.length > 0

--- a/frontend/admin/src/components/Menu/MenuList.jsx
+++ b/frontend/admin/src/components/Menu/MenuList.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import MenuItem from "./MenuItem";
 import { Box, Typography } from "@mui/material";
-import NavBar from "../GlobalComponents/NavBar";
 
 const MenuList = ({ items, selectedAllergies }) => {
   // アレルギーに基づいてソート
@@ -21,14 +20,16 @@ const MenuList = ({ items, selectedAllergies }) => {
 
   return (
     <>
-      <NavBar />
       <Box
         sx={{
           padding: 0,
           margin: "0 auto",
           overflowY: "auto",
-          // backgroundColor: "#f9f7f2",
           minHeight: "100vh",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          width: "100%",
         }}
       >
         <Typography
@@ -38,7 +39,8 @@ const MenuList = ({ items, selectedAllergies }) => {
             textAlign: "left",
             color: "#3c3a37",
             fontSize: "clamp(22px, 4vw, 28px)",
-            padding: "15px 10px",
+            padding:
+              "clamp(0.625rem, 0.511rem + 0.57vw, 0.938rem) clamp(0.625rem, 0.398rem + 1.14vw, 1.25rem)",
           }}
         >
           メニュー一覧
@@ -51,9 +53,11 @@ const MenuList = ({ items, selectedAllergies }) => {
               sm: "repeat(2, 1fr)", // タブレットでは2列
               md: "repeat(3, 1fr)", // PCでは3列
             },
-            gap: 1,
+            gap: "min(1rem, 3vw)",
             gridAutoRows: "minmax(auto, auto)",
-            padding: "10px 5px",
+            padding: "10px 50px",
+            width: "clamp(20rem, 100vw, 75rem)",
+            margin: "0 auto",
           }}
         >
           {sortedItems.map((item) => {

--- a/frontend/admin/src/pages/Home/home.jsx
+++ b/frontend/admin/src/pages/Home/home.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import styled from "styled-components";
 import MenuList from "../../components/Menu/MenuList";
 import { useEffect, useState } from "react";
@@ -6,7 +7,9 @@ const baseUrl = import.meta.env.VITE_API_BASE_URL;
 import AllergyFilterModal from "../../components/allergyFilterModal/allergyFilterModal";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { Box, CssBaseline } from "@mui/material";
-import AddCircleSharpIcon from "@mui/icons-material/AddCircleSharp";
+import AddButton from "../../components/Button/AddButton";
+import { useNavigate } from "react-router-dom";
+import NavBar from "../../components/GlobalComponents/NavBar";
 
 function Home() {
   const [menuItems, setMenuItems] = useState([]);
@@ -44,6 +47,12 @@ function Home() {
     setSelectedAllergies(selectedAllergiesOnFilter);
     // modalを閉じる
     setModalOpen(false);
+  };
+
+  // プラスボタンクリックで新規登録画面に遷移
+  const navigate = useNavigate();
+  const handleStartRegister = () => {
+    navigate("/admin/register");
   };
 
   useEffect(() => {
@@ -169,6 +178,7 @@ function Home() {
 
   return (
     <Frame>
+      <NavBar />
       <MenuList items={menuItems} selectedAllergies={selectedAllergies} />
       {isModalOpen && (
         <AllergyFilterModal
@@ -180,30 +190,7 @@ function Home() {
           onClick={handleConfirmAllergy}
         />
       )}
-      <Box
-        sx={{
-          position: "fixed",
-          bottom: "20px",
-          right: "20px",
-          zIndex: 1000,
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          width: "clamp(3.75rem, 3.214rem + 2.68vw, 5.625rem)",
-          height: "clamp(3.75rem, 3.214rem + 2.68vw, 5.625rem)",
-          borderRadius: "50%",
-          boxShadow: "0px 4px 6px rgba(0, 0, 0, 0.2)",
-        }}
-      >
-        <AddCircleSharpIcon
-          alt="Account Icon"
-          sx={{
-            color: "#f2a24a",
-            width: "100%",
-            height: "100%",
-          }}
-        />
-      </Box>
+      <AddButton onClick={handleStartRegister}></AddButton>
     </Frame>
   );
 }


### PR DESCRIPTION
`/admin/home`ページのUI調整・他ページへの遷移
- メニューカード
  - スマホだと1列、PCだと3列になるようにグリッドをレイアウト
  - 画面サイズによってフォントサイズ等を変更
  - 中央揃えに変更
    - 一部画面サイズだと左揃えっぽくなるのは直せなかった
    - 広い画面での違和感がなくなった
  - カード間の余白が少なかったので調整
- プラスボタン
  - スタイルの調整(ドロップシャドウがうまくつかなかった問題の解消)
  - ボタンを押すと`/admin/register`に遷移するように
- ホームボタン(MenuCareロゴ)
  - ボタンを押すと`/admin/home`に遷移するように