### PR TITLE
refactor: /menu ui update

### DIFF
--- a/frontend/admin/src/main.jsx
+++ b/frontend/admin/src/main.jsx
@@ -31,7 +31,7 @@ const router = createBrowserRouter([
 const theme = createTheme({
   palette: {
     background: {
-      default: "#f9f7f2", // 背景色を指定
+      default: "#f2ede5", // 背景色を指定
     },
   },
   typography: {

--- a/frontend/admin/vite.config.js
+++ b/frontend/admin/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
       manifest: {
         name: "MenuCare",
         short_name: "MenuCare",
-        theme_color: "#8B4513", // ブラウンカラー
+        theme_color: "#f2ede5", // ベージュカラー
         icons: [
           {
             src: "/vite.svg",

--- a/frontend/user/src/components/Menu/MenuItem.jsx
+++ b/frontend/user/src/components/Menu/MenuItem.jsx
@@ -10,8 +10,7 @@ import {
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
-
-const MenuItem = ({ item, onClick }) => { 
+const MenuItem = ({ item, onClick }) => {
   const price = Math.trunc(item.price);
   const [expanded, setExpanded] = useState(false);
 
@@ -24,13 +23,13 @@ const MenuItem = ({ item, onClick }) => {
     <>
       <Box sx={{ position: "relative", marginBottom: expanded ? 4 : 2 }}>
         <Card
-          onClick={() => onClick(item)} 
+          onClick={() => onClick(item)}
           sx={{
-            maxWidth: 300,
+            maxWidth: 286,
             borderRadius: 3,
             overflow: "hidden",
             textAlign: "left",
-            // height: "100%",
+            height: "auto",
           }}
         >
           <CardMedia
@@ -48,7 +47,7 @@ const MenuItem = ({ item, onClick }) => {
               fontWeight={700}
               sx={{
                 color: "#3c3a37",
-                fontSize: "clamp(18px, 4vw, 24px)",
+                fontSize: "clamp(16px, calc(1rem - 0.1vw), 24px)",
               }}
             >
               {item.name}
@@ -70,6 +69,7 @@ const MenuItem = ({ item, onClick }) => {
               sx={{
                 color: "#756e68",
                 paddingLeft: "5px",
+                fontSize: "clamp(0.75rem, 0.614rem + 0.68vw, 1.125rem)",
               }}
             >
               アレルギー情報

--- a/frontend/user/src/components/Menu/MenuList.jsx
+++ b/frontend/user/src/components/Menu/MenuList.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import MenuItem from "./MenuItem";
 import { Box, Typography } from "@mui/material";
 
-const MenuList = ({ items, selectedAllergies, onItemClick}) => {
+const MenuList = ({ items, selectedAllergies, onItemClick }) => {
   // アレルギーに基づいてソート
   const sortedItems = [...items].sort((a, b) => {
     const aHasAllergy = a.allergies.some((allergy) =>
@@ -24,6 +24,11 @@ const MenuList = ({ items, selectedAllergies, onItemClick}) => {
         padding: 0,
         margin: "0 auto",
         overflowY: "auto",
+        minHeight: "100vh",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        width: "100%",
       }}
     >
       <Typography
@@ -34,7 +39,8 @@ const MenuList = ({ items, selectedAllergies, onItemClick}) => {
           color: "#3c3a37",
           backgroundColor: "#fff",
           fontSize: "clamp(22px, 4vw, 28px)",
-          padding: "15px 10px",
+          padding:
+            "clamp(0.625rem, 0.511rem + 0.57vw, 0.938rem) clamp(0.625rem, 0.398rem + 1.14vw, 1.25rem)",
         }}
       >
         フード
@@ -42,11 +48,17 @@ const MenuList = ({ items, selectedAllergies, onItemClick}) => {
       <Box
         sx={{
           display: "grid",
-          gridTemplateColumns: "repeat(2, 1fr)",
+          gridTemplateColumns: {
+            xs: "repeat(2, 1fr)", // スマホでは2列
+            sm: "repeat(2, 1fr)", // タブレットでは2列
+            md: "repeat(3, 1fr)", // PCでは3列
+          },
           gap: 2,
           gridAutoRows: "minmax(auto, auto)",
           backgroundColor: "#f2ede5",
-          padding: "15px 10px",
+          padding: "20px clamp(0.938rem, -0.994rem + 9.66vw, 6.25rem)",
+          width: "clamp(20rem, 100vw, 75rem)",
+          margin: "0 auto",
         }}
       >
         {sortedItems.map((item) => {
@@ -61,7 +73,11 @@ const MenuList = ({ items, selectedAllergies, onItemClick}) => {
                 opacity: isGrayout ? 0.5 : 1, // グレーアウト
               }}
             >
-              <MenuItem key={item.id} item={item} onClick={() => onItemClick(item)} />
+              <MenuItem
+                key={item.id}
+                item={item}
+                onClick={() => onItemClick(item)}
+              />
             </Box>
           );
         })}

--- a/frontend/user/src/components/Menu/NavBar.jsx
+++ b/frontend/user/src/components/Menu/NavBar.jsx
@@ -8,15 +8,17 @@ import Toolbar from "@mui/material/Toolbar";
 import Box from "@mui/material/Box";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
-import { useNavigate } from "react-router-dom"; 
+import { useNavigate } from "react-router-dom";
 
 const NavBar = ({ openModal, cartItemCount }) => {
   const navigate = useNavigate();
   // openModalを受け取る
   const categoryButtons = [
     { id: 1, label: "すべて" },
-    { id: 2, label: "フード" },
-    { id: 3, label: "ドリンク" },
+    { id: 2, label: "前菜" },
+    { id: 3, label: "メイン" },
+    { id: 4, label: "デザート" },
+    { id: 5, label: "ドリンク" },
   ];
 
   const filterButtons = [
@@ -28,7 +30,7 @@ const NavBar = ({ openModal, cartItemCount }) => {
   const [selectedFilters, setSelectedFilters] = useState([]);
 
   const selectedStyle = {
-    padding: "0.8em 1.4em",
+    padding: "0.6em 1.2em",
     fontSize: "clamp(14px, 2vw, 18px)",
     color: "#fff",
     background: "linear-gradient(90deg, #f2994a, #f2c94c)",
@@ -49,7 +51,7 @@ const NavBar = ({ openModal, cartItemCount }) => {
   };
 
   const unselectedStyle = {
-    padding: "0.8em 1.4em",
+    padding: "0.6em 1.2em",
     fontSize: "clamp(14px, 2vw, 18px)",
     color: "#dbd6cd",
     background: "#fff",
@@ -102,34 +104,55 @@ const NavBar = ({ openModal, cartItemCount }) => {
           }}
         />
         <Toolbar sx={{ justifyContent: "space-between" }}>
+          <Box sx={{ width: "33%" }} />
           <Typography
             variant="h6"
             component="div"
             fontWeight={700}
             sx={{
-              flexGrow: 0,
+              flexGrow: 1,
               color: "#3c3a37",
               fontSize: "clamp(18px, 4vw, 28px)",
+              textAlign: "center",
             }}
           >
             メニュー一覧
           </Typography>
           {/* カートアイコン */}
-        <CartButton onClick={() => navigate("/cart")}> 
-          <ShoppingCartIcon />
-          {cartItemCount > 0 && <CartCount>{cartItemCount}</CartCount>}
-        </CartButton>
+          <Box
+            sx={{ width: "33%", display: "flex", justifyContent: "flex-end" }}
+          >
+            <CartButton onClick={() => navigate("/cart")}>
+              <ShoppingCartIcon />
+              {cartItemCount > 0 && <CartCount>{cartItemCount}</CartCount>}
+            </CartButton>
+          </Box>
         </Toolbar>
         <Container>
-          <Stack spacing={2} direction="row">
+          <Stack
+            spacing={2}
+            direction="row"
+            sx={{
+              overflowX: "auto", // 横スクロール
+              whiteSpace: "nowrap", // 折り返し無効
+              "-webkit-overflow-scrolling": "touch", // スムーズにスクロール
+              scrollbarWidth: "none", // Firefoxでスクロールバーを非表示
+              "&::-webkit-scrollbar": {
+                display: "none", // Chrome/Safariでスクロールバーを非表示
+              },
+            }}
+          >
             {categoryButtons.map((button) => (
               <button
                 key={button.id}
-                style={
-                  selectedCategory === button.id
+                style={{
+                  width: "clamp(5.625rem, 4.943rem + 3.41vw, 7.5rem)",
+                  height: "clamp(2.5rem, 2.159rem + 1.7vw, 3.438rem)",
+                  flexShrink: 0, // 横スクロール時に縮小させない
+                  ...(selectedCategory === button.id
                     ? selectedStyle
-                    : unselectedStyle
-                }
+                    : unselectedStyle),
+                }}
                 onClick={() => handleCategoryClick(button.id)}
               >
                 {button.label}
@@ -137,18 +160,29 @@ const NavBar = ({ openModal, cartItemCount }) => {
             ))}
           </Stack>
 
-          <Stack spacing={2} direction="row" sx={{ marginTop: "10px" }}>
+          <Stack
+            spacing={2}
+            direction="row"
+            sx={{
+              marginTop: "10px",
+              display: "flex",
+              justifyContent: "center",
+            }}
+          >
             {filterButtons.map((button) => (
               <button
                 key={button.id}
-                style={
-                  selectedFilters.includes(button.id)
+                style={{
+                  ...(selectedFilters.includes(button.id)
                     ? selectedStyle
-                    : unselectedStyle
-                }
+                    : unselectedStyle),
+                  display: "flex",
+                  alignItems: "center",
+                }}
                 onClick={() => handleFilterClick(button.id)}
               >
                 {button.label}
+                <ExpandMoreIcon />
               </button>
             ))}
           </Stack>

--- a/frontend/user/src/components/allergyFilterModal/allergyFilterModal.jsx
+++ b/frontend/user/src/components/allergyFilterModal/allergyFilterModal.jsx
@@ -8,24 +8,23 @@ function AllergyFilterModal({
   selectedAllergies,
   selectedAllergiesOnFilter,
   onToggle,
-  onClick
+  onClick,
 }) {
-
   // 配列要素比較 (共通部品にしたい)
   const arraysHaveSameElements = (arr1, arr2) => {
     if (arr1.length !== arr2.length) {
-        return false;
+      return false;
     }
     const sortedArr1 = arr1.slice().sort();
     const sortedArr2 = arr2.slice().sort();
-    
+
     for (let i = 0; i < sortedArr1.length; i++) {
-        if (sortedArr1[i] !== sortedArr2[i]) {
-            return false;
-        }
+      if (sortedArr1[i] !== sortedArr2[i]) {
+        return false;
+      }
     }
     return true;
-}
+  };
 
   //onClose のみだと上手くいかない
   return (
@@ -57,7 +56,14 @@ function AllergyFilterModal({
       </Section> */}
 
         <Footer>
-          {arraysHaveSameElements(selectedAllergies, selectedAllergiesOnFilter) ? <InactiveButton disabled={true}>メニューを絞り込む</InactiveButton> : <ActiveButton onClick={onClick}>メニューを絞り込む</ActiveButton>}
+          {arraysHaveSameElements(
+            selectedAllergies,
+            selectedAllergiesOnFilter
+          ) ? (
+            <InactiveButton disabled={true}>選択してください</InactiveButton>
+          ) : (
+            <ActiveButton onClick={onClick}>メニューを絞り込む</ActiveButton>
+          )}
         </Footer>
       </ModalContent>
     </ModalWrapper>
@@ -72,17 +78,17 @@ const ModalWrapper = styled.div`
   height: 100%;
   background: rgba(0, 0, 0, 0.5); /* 背景を暗くする？ */
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
   align-items: flex-end;
   z-index: 1000; /* 最前面に表示 */
 `;
 
 const ModalContent = styled.div`
   background: white;
-  padding: 20px;
+  padding: 15px;
   border-radius: 16px 16px 0 0;
   width: 100%;
-  max-width: 600px;
+  max-width: 95%;
   max-height: 80vh;
   overflow-y: auto;
   box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.2);
@@ -91,7 +97,6 @@ const ModalContent = styled.div`
 
   @media (max-width: 768px) {
     padding: 15px;
-    max-width: 95%;
   }
 
   @keyframes slideUp {
@@ -171,8 +176,8 @@ const ActiveButton = styled.button`
   font-family: "Noto Sans JP", sans-serif;
   color: white;
   background: linear-gradient(90deg, #f2994a, #f2c94c);
-  border: none;
-  border-radius: 30px;
+  border: 0.15em solid #fff;
+  border-radius: 2em;
   cursor: pointer;
 `;
 
@@ -181,10 +186,10 @@ const InactiveButton = styled.button`
   font-size: 14px;
   font-weight: 500;
   font-family: "Noto Sans JP", sans-serif;
-  color: white;
-  background: gray
-  border: none;
-  border-radius: 30px;
+  color: #a3978c;
+  background: #fff;
+  border: 0.15em solid #dbd6cd;
+  border-radius: 2em;
   cursor: pointer;
 `;
 

--- a/frontend/user/src/main.jsx
+++ b/frontend/user/src/main.jsx
@@ -7,6 +7,8 @@ import App from "./App.jsx";
 import Welcome from "./pages/Welcome/welcome.jsx";
 import Menu from "./pages/Menu/menu.jsx";
 import Cart from "./pages/Cart/cart.jsx";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import { CssBaseline } from "@mui/material";
 
 const router = createBrowserRouter([
   {
@@ -31,10 +33,26 @@ const router = createBrowserRouter([
   },
 ]);
 
+const theme = createTheme({
+  palette: {
+    background: {
+      default: "#f2ede5", // 背景色を指定
+    },
+  },
+  typography: {
+    fontFamily: ['"Noto Sans JP"', '"Open Sans"', "Arial", "sans-serif"].join(
+      ","
+    ),
+  },
+});
+
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <RecoilRoot>
-      <RouterProvider router={router} />
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <RouterProvider router={router} />
+      </ThemeProvider>
     </RecoilRoot>
   </StrictMode>
 );

--- a/frontend/user/src/pages/Menu/menu.jsx
+++ b/frontend/user/src/pages/Menu/menu.jsx
@@ -11,24 +11,25 @@ import { createTheme, ThemeProvider } from "@mui/material/styles";
 import ProductModal from "../../components/ProductModal/ProductModal";
 import { useLocation } from "react-router-dom";
 
-
 function Menu() {
   // Global Stateの利用例です
   const [test, setTest] = useRecoilState(globalStateTest);
 
-// Menu Item
+  // Menu Item
   const [menuItems, setMenuItems] = useState([]);
   const [cartItems, setCartItems] = useState([]); // カートの状態を管理
   const [selectedProduct, setSelectedProduct] = useState(null); // 選択された商品
   const [isProductModalOpen, setProductModalOpen] = useState(false);
-  
-// Allergy
+
+  // Allergy
   const [allergies, setAllergies] = useState([]); // アレルギー情報を管理
   const [selectedAllergies, setSelectedAllergies] = useState([]); // 選択されたアレルギーを管理
-  const [selectedAllergiesOnFilter, setSelectedAllergiesOnFilter] = useState([]); // filter上で選択中のアレルギー情報を管理
+  const [selectedAllergiesOnFilter, setSelectedAllergiesOnFilter] = useState(
+    []
+  ); // filter上で選択中のアレルギー情報を管理
   const [isModalOpen, setModalOpen] = useState(false);
 
-//popup
+  //popup
   const location = useLocation(); // `navigate` からのメッセージ受け取り
   const [popupMessage, setPopupMessage] = useState(""); // ポップアップメッセージを管理
 
@@ -43,7 +44,6 @@ function Menu() {
     }
   }, [location.state]);
 
-
   // カート情報のローカルストレージ保存と取得
   useEffect(() => {
     localStorage.setItem("cart", JSON.stringify(cartItems));
@@ -56,7 +56,7 @@ function Menu() {
         setCartItems(JSON.parse(savedCart));
       } catch (error) {
         console.error("Failed to parse cart data:", error);
-        setCartItems([]); 
+        setCartItems([]);
       }
     }
   }, []);
@@ -68,7 +68,7 @@ function Menu() {
     setModalOpen(false);
     // selectedAllergiesOnFilterをselectedAllergiesの値にリセットする ※ modalを開いた際の初期値を選択中のアレルギー情報にするため
     setSelectedAllergiesOnFilter(selectedAllergies);
-  }
+  };
 
   // 商品モーダルの開閉状態を管理
   const openProductModal = (product) => {
@@ -84,7 +84,9 @@ function Menu() {
   // カートに商品追加
   const addToCart = (product, quantity) => {
     setCartItems((prev) => {
-      const existingItem = prev.find((item) => item.menu_id === product.menu_id);
+      const existingItem = prev.find(
+        (item) => item.menu_id === product.menu_id
+      );
       if (existingItem) {
         return prev.map((item) =>
           item.menu_id === product.menu_id
@@ -124,9 +126,6 @@ function Menu() {
     },
   });
 
-
-
-
   useEffect(() => {
     try {
       const fetchMenuItems = async () => {
@@ -139,7 +138,50 @@ function Menu() {
         // setMenuItems(res.data);
 
         // backendを繋げていない環境ではこちら
-        const testData = [{"menu_id":1,"name":"目玉焼き","price":"1000.00","image_url":"src/assets/egg.png","allergies":["卵"]},{"menu_id":2,"name":"ガトーショコラ","price":"1500.00","image_url":"src/assets/cake.png","allergies":["卵","小麦","乳（牛乳）"]},{"menu_id":3,"name":"生ハムのサラダ","price":"800.00","image_url":"src/assets/salad.png","allergies":["卵","乳（牛乳）"]},{"menu_id":4,"name":"鶏肉のごま味噌焼き","price":"800.00","image_url":"src/assets/chicken.png","allergies":["ごま","鶏肉"]},{"menu_id":5,"name":"トマトパスタ","price":"1000.00","image_url":"src/assets/pasta.png","allergies":["小麦"]},{"menu_id":6,"name":"エビチリ","price":"700.00","image_url":"src/assets/ebichiri.png","allergies":["えび"]}];
+        const testData = [
+          {
+            menu_id: 1,
+            name: "目玉焼き",
+            price: "1000.00",
+            image_url: "src/assets/egg.png",
+            allergies: ["卵"],
+          },
+          {
+            menu_id: 2,
+            name: "ガトーショコラ",
+            price: "1500.00",
+            image_url: "src/assets/cake.png",
+            allergies: ["卵", "小麦", "乳（牛乳）"],
+          },
+          {
+            menu_id: 3,
+            name: "生ハムのサラダ",
+            price: "800.00",
+            image_url: "src/assets/salad.png",
+            allergies: ["卵", "乳（牛乳）"],
+          },
+          {
+            menu_id: 4,
+            name: "鶏肉のごま味噌焼き",
+            price: "800.00",
+            image_url: "src/assets/chicken.png",
+            allergies: ["ごま", "鶏肉"],
+          },
+          {
+            menu_id: 5,
+            name: "トマトパスタ",
+            price: "1000.00",
+            image_url: "src/assets/pasta.png",
+            allergies: ["小麦"],
+          },
+          {
+            menu_id: 6,
+            name: "エビチリ",
+            price: "700.00",
+            image_url: "src/assets/ebichiri.png",
+            allergies: ["えび"],
+          },
+        ];
         setMenuItems(testData);
       };
       fetchMenuItems();
@@ -155,9 +197,9 @@ function Menu() {
     const fetchAllergies = async () => {
       try {
         // local上での実行の際はこちら
-        const res = await axios.get(`${baseUrl}/allergies`);
-        console.log("alg:",res.data);
-        setAllergies(res.data);
+        // const res = await axios.get(`${baseUrl}/allergies`);
+        // console.log("alg:",res.data);
+        // setAllergies(res.data);
 
         // lambda上での実行の際はこちら
         // const res = await axios.get(`https://api.menu-care.com/api/allergies`);
@@ -208,7 +250,10 @@ function Menu() {
   return (
     <Frame>
       <NavBar
-        cartItemCount={cartItems.reduce((total, item) => total + item.quantity, 0)} // カート内の数量合計
+        cartItemCount={cartItems.reduce(
+          (total, item) => total + item.quantity,
+          0
+        )} // カート内の数量合計
         openModal={openModal}
       />
       {/* ポップアップメッセージ */}
@@ -263,7 +308,7 @@ const Popup = styled.div`
   left: 50%;
   transform: translateX(-50%);
   font-family: "Noto Sans JP", sans-serif;
-  background: linear-gradient(90deg, #f2994a, #f2c94c); 
+  background: linear-gradient(90deg, #f2994a, #f2c94c);
   color: #fff;
   padding: 15px 30px;
   border-radius: 8px;

--- a/frontend/user/vite.config.js
+++ b/frontend/user/vite.config.js
@@ -1,23 +1,22 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import { VitePWA } from 'vite-plugin-pwa';
-
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { VitePWA } from "vite-plugin-pwa";
 
 // https://vite.dev/config/
 export default defineConfig({
-    plugins: [
+  plugins: [
     react(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: "autoUpdate",
       manifest: {
-        name: 'MenuCare',
-        short_name: 'MenuCare',
-        theme_color: '#8B4513', // ブラウンカラー
+        name: "MenuCare",
+        short_name: "MenuCare",
+        theme_color: "#f2ede5", // ベージュカラー
         icons: [
           {
-            src: '/vite.svg',
-            sizes: '512x512',
-            type: 'image/svg+xml',
+            src: "/vite.svg",
+            sizes: "512x512",
+            type: "image/svg+xml",
           },
         ],
       },
@@ -25,9 +24,9 @@ export default defineConfig({
   ],
   server: {
     proxy: {
-      '/api' : {
-        target: 'http://localhost:3000'
-      }
-    }
-  }
-})
+      "/api": {
+        target: "http://localhost:3000",
+      },
+    },
+  },
+});


### PR DESCRIPTION
`frontend\user\src\components\Menu\NavBar.jsx`
- 「アレルギーあり」に▽つけてモーダルが展開されることをわかりやすくする
- フィルタを中央寄せに
- 上の各種ボタンを中央寄せ or 別の項目を作って横スクロールされるように
- 【＋α】「メニュー一覧」が左寄せになってたので中央に直した

`frontend\user\src\components\Menu\MenuList.jsx`
- 余白を入れる
- PCサイズにしたときに崩れるのを治したい

`frontend\user\src\components\Menu\MenuItem.jsx`
- 【＋α】上記レイアウト変更に伴う微調整

`frontend\user\src\components\allergyFilterModal\allergyFilterModal.jsx`
- 【＋α】モーダルの幅、絞り込みボタンのスタイル調整